### PR TITLE
feat: Add report download functionality

### DIFF
--- a/src/JsonTreeCompareViewer.download.test.js
+++ b/src/JsonTreeCompareViewer.download.test.js
@@ -1,0 +1,208 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import JsonTreeCompareViewer from './JsonTreeCompareViewer';
+// Import html2pdf.js to be mocked. The actual library is not used in tests.
+import html2pdf from 'html2pdf.js';
+
+// --- Mocks Setup ---
+
+// Mock html2pdf.js
+const mockHtml2pdfSave = jest.fn().mockResolvedValue(undefined); // To simulate async save operation
+const mockHtml2pdfInstance = {
+  from: jest.fn().mockReturnThis(),
+  set: jest.fn().mockReturnThis(),
+  save: mockHtml2pdfSave,
+};
+jest.mock('html2pdf.js', () => jest.fn(() => mockHtml2pdfInstance));
+
+// Mock URL.createObjectURL and URL.revokeObjectURL
+global.URL.createObjectURL = jest.fn(() => 'mock-object-url');
+global.URL.revokeObjectURL = jest.fn();
+
+// Declare spies/mocks that will be initialized in beforeEach
+let mockAlert;
+let jsonStringifySpy;
+let mockDocumentCreateElement;
+let mockBodyAppendChild;
+let mockBodyRemoveChild;
+
+beforeEach(() => {
+  // Window method mocks
+  mockAlert = jest.spyOn(window, 'alert').mockImplementation(() => {}); // Mock alert to prevent dialogs
+
+  // JSON.stringify spy
+  jsonStringifySpy = jest.spyOn(JSON, 'stringify');
+
+  // DOM manipulation spies
+  mockDocumentCreateElement = jest.spyOn(document, 'createElement');
+  mockBodyAppendChild = jest.spyOn(document.body, 'appendChild').mockImplementation(node => node);
+  mockBodyRemoveChild = jest.spyOn(document.body, 'removeChild').mockImplementation(node => node);
+
+  // Clear mocks for html2pdf.js and URL object methods for each test
+  mockHtml2pdfInstance.from.mockClear();
+  mockHtml2pdfInstance.set.mockClear();
+  mockHtml2pdfSave.mockClear();
+  global.URL.createObjectURL.mockClear();
+  global.URL.revokeObjectURL.mockClear();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks(); // This will restore window.alert, JSON.stringify, document.createElement, etc.
+});
+
+// --- Test Suite ---
+
+describe('JsonTreeCompareViewer Download Functionality', () => {
+  const leftJson = { a: 1, b: "hello" };
+  const rightJson = { a: 1, b: "world", c: true };
+  const leftJsonString = JSON.stringify(leftJson); // Use actual stringify for test data setup
+  const rightJsonString = JSON.stringify(rightJson); // Use actual stringify for test data setup
+
+  // Helper to perform comparison and enable download button
+  const setupForDownload = async () => {
+    render(<JsonTreeCompareViewer />);
+    fireEvent.change(screen.getByPlaceholderText('Enter left JSON here'), { target: { value: leftJsonString } });
+    fireEvent.change(screen.getByPlaceholderText('Enter right JSON here'), { target: { value: rightJsonString } });
+    fireEvent.click(screen.getByText('Compare'));
+    await screen.findByText('Comparison Statistics'); // Wait for comparison to complete
+    const downloadReportButton = screen.getByRole('button', { name: /Download Report/i });
+    expect(downloadReportButton).not.toBeDisabled();
+    fireEvent.click(downloadReportButton); // Open dropdown
+  };
+
+  describe('Initial State', () => {
+    test('Download Report button is disabled initially', () => {
+      render(<JsonTreeCompareViewer />);
+      const downloadReportButton = screen.getByRole('button', { name: /Download Report/i });
+      expect(downloadReportButton).toBeDisabled();
+    });
+  });
+
+  describe('JSON Download', () => {
+    // Specific beforeEach for JSON download if needed, e.g. for the 'a' element mock
+    let mockAnchorClick;
+
+    beforeEach(() => {
+      mockAnchorClick = jest.fn();
+      // Refine the createElement mock for 'a' tags specifically for JSON download tests
+      mockDocumentCreateElement.mockImplementation((tagName) => {
+        if (tagName.toLowerCase() === 'a') {
+          const mockAnchor = {
+            href: '',
+            download: '',
+            click: mockAnchorClick,
+            setAttribute: jest.fn(),
+            removeAttribute: jest.fn(),
+            style: {}, // Ensure style property exists
+          };
+          return mockAnchor;
+        }
+        // Fallback for other elements not created by the download function
+        return document.createElementNS('http://www.w3.org/1999/xhtml', tagName);
+      });
+    });
+    
+    test('successfully downloads a JSON report', async () => {
+      await setupForDownload();
+      
+      const downloadJsonButton = screen.getByText('Download as JSON');
+      fireEvent.click(downloadJsonButton);
+
+      await waitFor(() => {
+        expect(jsonStringifySpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            leftJson: leftJsonString,
+            rightJson: rightJsonString,
+            comparisonStats: expect.objectContaining({ // Actual stats for the given JSONs
+              totalLeftItems: 2,
+              totalRightItems: 3,
+              commonPaths: 2,
+              matchingValues: 1,
+              differentValues: 1,
+              onlyInLeft: 0,
+              onlyInRight: 1,
+            }),
+          }),
+          null, // for replacer function
+          2     // for space argument (pretty-printing)
+        );
+      });
+      
+      expect(global.URL.createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+      const blobInstance = global.URL.createObjectURL.mock.calls[0][0];
+      expect(blobInstance.type).toBe('application/json');
+
+      expect(mockDocumentCreateElement).toHaveBeenCalledWith('a');
+      const mockAnchorInstance = mockDocumentCreateElement.mock.results.find(r => r.value.click === mockAnchorClick)?.value;
+      expect(mockAnchorInstance).toBeDefined();
+      if (mockAnchorInstance) {
+        expect(mockAnchorInstance.href).toBe('mock-object-url');
+        expect(mockAnchorInstance.download).toBe('comparison_report.json');
+      }
+      expect(mockAnchorClick).toHaveBeenCalled();
+
+      expect(mockBodyAppendChild).toHaveBeenCalledWith(mockAnchorInstance);
+      expect(mockBodyRemoveChild).toHaveBeenCalledWith(mockAnchorInstance);
+      expect(global.URL.revokeObjectURL).toHaveBeenCalledWith('mock-object-url');
+    });
+  });
+
+  describe('PDF Download', () => {
+    beforeEach(() => {
+      // Ensure createElement returns actual divs for PDF generation part
+      mockDocumentCreateElement.mockImplementation((tagName) => 
+        document.createElementNS('http://www.w3.org/1999/xhtml', tagName)
+      );
+    });
+
+    test('successfully generates HTML and initiates PDF download', async () => {
+      await setupForDownload();
+
+      const downloadPdfButton = screen.getByText('Download as PDF');
+      await act(async () => { // Use act for state updates / async operations
+        fireEvent.click(downloadPdfButton);
+      });
+
+      expect(html2pdf).toHaveBeenCalledTimes(1);
+      expect(mockHtml2pdfInstance.from).toHaveBeenCalledWith(expect.any(HTMLDivElement));
+      
+      const passedElement = mockHtml2pdfInstance.from.mock.calls[0][0];
+      expect(passedElement.innerHTML).toContain('JSON Comparison Report');
+      expect(passedElement.innerHTML).toContain('Comparison Statistics:');
+      // Based on leftJson and rightJson for this test suite
+      expect(passedElement.innerHTML).toContain('Total Left Items:</strong> 2');
+      expect(passedElement.innerHTML).toContain('Total Right Items:</strong> 3');
+      expect(passedElement.innerHTML).toContain('Common Paths:</strong> 2');
+      expect(passedElement.innerHTML).toContain('Matching Values:</strong> 1');
+      expect(passedElement.innerHTML).toContain('Different Values:</strong> 1');
+      expect(passedElement.innerHTML).toContain('Only In Left:</strong> 0'); // Corrected from 'Exclusive to Left' to match implementation
+      expect(passedElement.innerHTML).toContain('Only In Right:</strong> 1'); // Corrected from 'Exclusive to Right'
+
+      expect(mockHtml2pdfInstance.set).toHaveBeenCalledWith(expect.objectContaining({
+        filename: 'comparison_report.pdf',
+        margin: [10, 10, 10, 10],
+      }));
+      expect(mockHtml2pdfSave).toHaveBeenCalledTimes(1);
+      
+      await waitFor(() => {
+         expect(mockAlert).toHaveBeenCalledWith('PDF report download started. Please check your downloads.');
+      });
+    });
+
+    test('handles error during PDF generation and shows alert', async () => {
+      await setupForDownload();
+      mockHtml2pdfSave.mockRejectedValueOnce(new Error('Test PDF Generation Error'));
+
+      const downloadPdfButton = screen.getByText('Download as PDF');
+      await act(async () => {
+        fireEvent.click(downloadPdfButton);
+      });
+      
+      expect(mockHtml2pdfSave).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(mockAlert).toHaveBeenCalledWith('Failed to generate or download PDF report: Test PDF Generation Error. See console for details.');
+      });
+    });
+  });
+});

--- a/src/JsonTreeCompareViewer.jsx
+++ b/src/JsonTreeCompareViewer.jsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect } from 'react';
-import { AlertCircle, ChevronDown, ChevronRight, Copy, RefreshCw, X, Save, FolderOpen, Trash2, HelpCircle } from 'lucide-react';
+import React, { useState, useEffect, useRef } from 'react';
+import { AlertCircle, ChevronDown, ChevronRight, Copy, RefreshCw, X, Save, FolderOpen, Trash2, HelpCircle, Download, ChevronUp } from 'lucide-react';
 import { Alert, AlertDescription, AlertTitle } from './components/ui/alert';
+import html2pdf from 'html2pdf.js';
 import { Button } from './components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from './components/ui/card';
 import DarkModeToggle from './components/DarkModeToggle';
@@ -106,6 +107,8 @@ const JsonTreeCompareViewer = () => {
   const [selectedSessionId, setSelectedSessionId] = useState(''); // For dropdown selection and delete target
   const [isHelpModalOpen, setIsHelpModalOpen] = useState(false);
   const [comparisonStats, setComparisonStats] = useState(null);
+  const [isDownloadDropdownOpen, setIsDownloadDropdownOpen] = useState(false);
+  const dropdownRef = useRef(null);
 
   const toggleDarkMode = () => {
     setDarkMode((prevDarkMode) => !prevDarkMode);
@@ -118,6 +121,19 @@ const JsonTreeCompareViewer = () => {
       document.documentElement.classList.remove('dark');
     }
   }, [darkMode]);
+
+  // Effect to handle clicks outside the dropdown
+  useEffect(() => {
+    function handleClickOutside(event) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        setIsDownloadDropdownOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [dropdownRef]);
 
   // Load sessions from Local Storage on component mount
   useEffect(() => {
@@ -159,6 +175,101 @@ const JsonTreeCompareViewer = () => {
       setParsedLeft(null); 
       setParsedRight(null);
       setComparisonStats(null); // Clear stats on error
+    }
+  };
+
+  const handleDownloadJson = () => {
+    if (!leftJson || !rightJson || !comparisonStats) {
+      console.error('Missing data for JSON report download.');
+      alert('Cannot download JSON report: Missing JSON input or comparison data.');
+      setIsDownloadDropdownOpen(false);
+      return;
+    }
+
+    const reportData = {
+      leftJson: leftJson, // Raw string
+      rightJson: rightJson, // Raw string
+      comparisonStats: comparisonStats,
+    };
+
+    try {
+      const jsonString = JSON.stringify(reportData, null, 2);
+      const blob = new Blob([jsonString], { type: 'application/json' });
+      const objectUrl = URL.createObjectURL(blob);
+
+      const a = document.createElement('a');
+      a.href = objectUrl;
+      a.download = 'comparison_report.json';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+
+      URL.revokeObjectURL(objectUrl);
+      console.log('JSON report download initiated.');
+    } catch (error) {
+      console.error('Error generating or downloading JSON report:', error);
+      alert('Failed to generate or download JSON report. See console for details.');
+    }
+
+    setIsDownloadDropdownOpen(false); // Close dropdown after action
+  };
+
+  const handleDownloadPdf = async () => {
+    if (!comparisonStats) {
+      console.error('Missing data for PDF report download.');
+      alert('Cannot download PDF report: Missing comparison data.');
+      setIsDownloadDropdownOpen(false);
+      return;
+    }
+
+    const reportElement = document.createElement('div');
+    // Apply some basic styling for the PDF content
+    reportElement.style.padding = '20px';
+    reportElement.style.fontFamily = 'Arial, sans-serif';
+    reportElement.style.lineHeight = '1.6';
+    reportElement.style.color = '#333';
+
+    let htmlContent = `
+      <h1 style="text-align: center; color: #333; border-bottom: 2px solid #eee; padding-bottom: 10px;">JSON Comparison Report</h1>
+      <h2 style="color: #555;">Comparison Statistics:</h2>
+      <ul style="list-style-type: none; padding: 0;">
+    `;
+
+    for (const [key, value] of Object.entries(comparisonStats)) {
+      // Convert camelCase key to Title Case for readability
+      const titleKey = key.replace(/([A-Z])/g, ' $1').replace(/^./, (str) => str.toUpperCase());
+      htmlContent += `<li style="padding: 5px 0; border-bottom: 1px solid #f0f0f0;"><strong>${titleKey}:</strong> ${value}</li>`;
+    }
+
+    htmlContent += `</ul>`;
+    reportElement.innerHTML = htmlContent;
+
+    // Append to body to be processed by html2pdf, but make it invisible
+    reportElement.style.position = 'absolute';
+    reportElement.style.left = '-9999px';
+    reportElement.style.top = '-9999px';
+    document.body.appendChild(reportElement);
+
+    const options = {
+      margin: [10, 10, 10, 10], // top, right, bottom, left in mm
+      filename: 'comparison_report.pdf',
+      image: { type: 'jpeg', quality: 0.98 },
+      html2canvas: { scale: 2, logging: false, useCORS: true }, // Added logging: false and useCORS
+      jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
+      pagebreak: { mode: ['avoid-all', 'css', 'legacy'] }
+    };
+
+    try {
+      console.log('Initiating PDF download with html2pdf.js...');
+      await html2pdf().from(reportElement).set(options).save();
+      console.log('PDF report download initiated.');
+      alert('PDF report download started. Please check your downloads.');
+    } catch (error) {
+      console.error('Error generating or downloading PDF report:', error);
+      alert(`Failed to generate or download PDF report: ${error.message}. See console for details.`);
+    } finally {
+      document.body.removeChild(reportElement); // Clean up the temporary element
+      setIsDownloadDropdownOpen(false); // Close dropdown after action
     }
   };
 
@@ -391,6 +502,37 @@ const JsonTreeCompareViewer = () => {
             <Button onClick={handleCompare} className="w-full bg-gray-900 text-white hover:bg-gray-800 transition-colors dark:bg-gray-600 dark:hover:bg-gray-500">
               Compare
             </Button>
+
+            <div className="mt-4 relative" ref={dropdownRef}>
+              <Button 
+                onClick={() => setIsDownloadDropdownOpen(!isDownloadDropdownOpen)} 
+                disabled={!comparisonStats}
+                variant="outline"
+                className="w-full dark:text-white dark:border-white flex items-center justify-center"
+              >
+                <Download className="h-4 w-4 mr-2" />
+                Download Report
+                {isDownloadDropdownOpen ? <ChevronUp className="h-4 w-4 ml-2" /> : <ChevronDown className="h-4 w-4 ml-2" />}
+              </Button>
+              {isDownloadDropdownOpen && (
+                <div className="absolute z-10 mt-1 w-full bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-md shadow-lg">
+                  <div 
+                    onClick={handleDownloadJson}
+                    className="px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 cursor-pointer flex items-center"
+                  >
+                    <Download className="h-4 w-4 mr-2 text-gray-700 dark:text-gray-300" />
+                    Download as JSON
+                  </div>
+                  <div 
+                    onClick={handleDownloadPdf}
+                    className="px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 cursor-pointer flex items-center"
+                  >
+                    <Download className="h-4 w-4 mr-2 text-gray-700 dark:text-gray-300" />
+                    Download as PDF
+                  </div>
+                </div>
+              )}
+            </div>
           </CardContent>
         </Card>
 


### PR DESCRIPTION
Adds the capability for you to download the JSON comparison report. Reports can be downloaded in two formats:

1.  **JSON Format:** A `.json` file containing the raw left and right JSON inputs and the detailed comparison statistics object.
2.  **PDF Format:** A `.pdf` file summarizing the comparison statistics, including total items, common paths, differences, etc. This is generated client-side using `html2pdf.js`.

**Key Changes:**

-   Added a "Download Report" dropdown button to the `JsonTreeCompareViewer` component, enabled after a comparison is run.
-   Implemented `handleDownloadJson` to construct and trigger the download of the JSON report.
-   Implemented `handleDownloadPdf` to generate an HTML summary of stats and use `html2pdf.js` to convert and download it as a PDF.
-   Ensured the UI is user-friendly by providing a single point of access for downloads and appropriate button states.
-   Refactored to remove any redundant UI elements for downloading.