### PR TITLE
Feat/keyboard shortcuts

### DIFF
--- a/src/JsonTreeCompareViewer.jsx
+++ b/src/JsonTreeCompareViewer.jsx
@@ -145,6 +145,38 @@ const JsonTreeCompareViewer = () => {
     }
   }, [searchQuery, parsedLeft, parsedRight]);
 
+  // Keyboard shortcuts
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+      const modifierKey = isMac ? event.metaKey : event.ctrlKey;
+
+      if (modifierKey && event.shiftKey && event.key === 'C') {
+        event.preventDefault();
+        handleCopy('left'); // Or 'right', or implement a way to choose
+        console.log("Left JSON copied to clipboard via shortcut.");
+      } else if (modifierKey && event.shiftKey && event.key === 'L') {
+        event.preventDefault();
+        handleClear('left');
+        console.log("Left JSON cleared via shortcut.");
+      } else if (modifierKey && event.shiftKey && event.key === 'R') {
+        event.preventDefault();
+        handleClear('right');
+        console.log("Right JSON cleared via shortcut.");
+      } else if (modifierKey && event.key.toLowerCase() === 'd') { // Cmd+D or Ctrl+D, ensure lowercase 'd'
+        event.preventDefault();
+        toggleDarkMode();
+        console.log("Dark mode toggled via shortcut.");
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []); // Empty dependency array means this effect runs once on mount and cleans up on unmount
+
   const handleCompare = () => {
     try {
       const pLeft = JSON.parse(leftJson);

--- a/src/JsonTreeCompareViewer.test.js
+++ b/src/JsonTreeCompareViewer.test.js
@@ -562,3 +562,77 @@ describe('JsonTreeCompareViewer Integration Tests', () => {
       });
   });
 });
+
+// --- Keyboard Shortcut Tests ---
+describe('JsonTreeCompareViewer Keyboard Shortcuts', () => {
+  let consoleLogSpy;
+
+  beforeEach(() => {
+    // Spy on console.log before each test in this suite
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    // Ensure navigator.clipboard.writeText is fresh for each test
+    navigator.clipboard.writeText.mockClear(); 
+  });
+
+  afterEach(() => {
+    // Restore console.log
+    consoleLogSpy.mockRestore();
+    // Clear the class list for documentElement after dark mode tests
+    document.documentElement.classList.remove('dark');
+  });
+
+  const testCases = [
+    { description: 'Ctrl', keyProps: { ctrlKey: true, metaKey: false } },
+    { description: 'Meta (Cmd)', keyProps: { ctrlKey: false, metaKey: true } },
+  ];
+
+  testCases.forEach(({ description, keyProps }) => {
+    describe(`With ${description} Key`, () => {
+      test(`toggles dark mode with ${description}+D`, () => {
+        render(<JsonTreeCompareViewer />);
+        expect(document.documentElement.classList.contains('dark')).toBe(false);
+
+        fireEvent.keyDown(document, { key: 'd', ...keyProps });
+        expect(document.documentElement.classList.contains('dark')).toBe(true);
+        expect(consoleLogSpy).toHaveBeenCalledWith('Dark mode toggled via shortcut.');
+
+        fireEvent.keyDown(document, { key: 'D', ...keyProps }); // Test with uppercase D
+        expect(document.documentElement.classList.contains('dark')).toBe(false);
+        expect(consoleLogSpy).toHaveBeenCalledWith('Dark mode toggled via shortcut.');
+      });
+
+      test(`copies left JSON with ${description}+Shift+C`, () => {
+        const { getByPlaceholderText } = render(<JsonTreeCompareViewer />);
+        const leftInput = getByPlaceholderText('Enter left JSON here');
+        const testJson = '{"name":"test"}';
+        fireEvent.change(leftInput, { target: { value: testJson } });
+
+        fireEvent.keyDown(document, { key: 'C', shiftKey: true, ...keyProps });
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(testJson);
+        expect(consoleLogSpy).toHaveBeenCalledWith('Left JSON copied to clipboard via shortcut.');
+      });
+
+      test(`clears left JSON with ${description}+Shift+L`, () => {
+        const { getByPlaceholderText } = render(<JsonTreeCompareViewer />);
+        const leftInput = getByPlaceholderText('Enter left JSON here');
+        fireEvent.change(leftInput, { target: { value: '{"data":"left"}' } });
+        expect(leftInput.value).toBe('{"data":"left"}');
+
+        fireEvent.keyDown(document, { key: 'L', shiftKey: true, ...keyProps });
+        expect(leftInput.value).toBe('');
+        expect(consoleLogSpy).toHaveBeenCalledWith('Left JSON cleared via shortcut.');
+      });
+
+      test(`clears right JSON with ${description}+Shift+R`, () => {
+        const { getByPlaceholderText } = render(<JsonTreeCompareViewer />);
+        const rightInput = getByPlaceholderText('Enter right JSON here');
+        fireEvent.change(rightInput, { target: { value: '{"data":"right"}' } });
+        expect(rightInput.value).toBe('{"data":"right"}');
+
+        fireEvent.keyDown(document, { key: 'R', shiftKey: true, ...keyProps });
+        expect(rightInput.value).toBe('');
+        expect(consoleLogSpy).toHaveBeenCalledWith('Right JSON cleared via shortcut.');
+      });
+    });
+  });
+});

--- a/src/components/HelpModal.jsx
+++ b/src/components/HelpModal.jsx
@@ -112,8 +112,27 @@ const HelpModal = ({ isOpen, onClose }) => {
             </ul>
           </section>
 
+          <section className="mb-4">
+            <h4 className="text-lg font-semibold mb-2 text-gray-800 dark:text-white">VIII. Keyboard Shortcuts</h4>
+            <p className="mb-1">Use these shortcuts for faster navigation and actions:</p>
+            <ul className="list-disc list-inside space-y-1 pl-4">
+              <li>
+                <strong>Toggle Dark Mode:</strong> <kbd>Ctrl</kbd> + <kbd>D</kbd> (or <kbd>Cmd</kbd> + <kbd>D</kbd> on Mac)
+              </li>
+              <li>
+                <strong>Copy Left JSON:</strong> <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd> (or <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd> on Mac)
+              </li>
+              <li>
+                <strong>Clear Left JSON:</strong> <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>L</kbd> (or <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>L</kbd> on Mac)
+              </li>
+              <li>
+                <strong>Clear Right JSON:</strong> <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>R</kbd> (or <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>R</kbd> on Mac)
+              </li>
+            </ul>
+          </section>
+
           <section>
-            <h4 className="text-lg font-semibold mb-2 text-gray-800 dark:text-white">VIII. Tips for Effective Use</h4>
+            <h4 className="text-lg font-semibold mb-2 text-gray-800 dark:text-white">IX. Tips for Effective Use</h4>
             <ul className="list-disc list-inside space-y-1">
               <li>For large JSON, use the search and expand/collapse features to navigate efficiently.</li>
               <li>Ensure your JSON is valid before pasting. Online JSON validators can help if you encounter issues.</li>


### PR DESCRIPTION
Adds keyboard shortcuts for:
- Toggle Dark Mode: Ctrl+D (Cmd+D on Mac)
- Copy Left JSON: Ctrl+Shift+C (Cmd+Shift+C on Mac)
- Clear Left JSON: Ctrl+Shift+L (Cmd+Shift+L on Mac)
- Clear Right JSON: Ctrl+Shift+R (Cmd+Shift+R on Mac)

Includes:
- Event listener setup in JsonTreeCompareViewer.jsx.
- Integration with existing handler functions.
- Unit tests for all new shortcuts.
- Updated HelpModal.jsx with shortcut information.