### PR TITLE
feat: Add download functionality for comparison reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "class-variance-authority": "^0.7.0",
+        "jspdf": "^3.0.1",
+        "jspdf-autotable": "^5.0.2",
         "lucide-react": "^0.428.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -1961,12 +1963,9 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "node_modules/@babel/runtime": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.0.tgz",
-      "integrity": "sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
+      "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -4429,6 +4428,12 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
       "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg=="
     },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "optional": true
+    },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
@@ -5366,6 +5371,17 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
@@ -5720,6 +5736,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -5897,6 +5922,17 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -6004,6 +6040,25 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
@@ -6447,6 +6502,15 @@
       },
       "peerDependencies": {
         "postcss": "^8.4"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-loader": {
@@ -7142,6 +7206,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -8371,6 +8444,11 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -9304,6 +9382,19 @@
         "webpack": {
           "optional": true
         }
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/htmlparser2": {
@@ -12289,6 +12380,31 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jspdf": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.1.tgz",
+      "integrity": "sha512-qaGIxqxetdoNnFQQXxTKUD9/Z7AloLaw94fFsOiJMxbfYdBbrBuhWmbzI8TVjrw7s3jBY1PFHofBKMV/wZPapg==",
+      "dependencies": {
+        "@babel/runtime": "^7.26.7",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.2.4",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/jspdf-autotable": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-5.0.2.tgz",
+      "integrity": "sha512-YNKeB7qmx3pxOLcNeoqAv3qTS7KuvVwkFe5AduCawpop3NOkBUtqDToxNc225MlNecxT4kP2Zy3z/y/yvGdXUQ==",
+      "peerDependencies": {
+        "jspdf": "^2 || ^3"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -14820,11 +14936,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/react-app-polyfill/node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
-    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -15193,9 +15304,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
@@ -15422,6 +15533,15 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rimraf": {
@@ -16092,6 +16212,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/stackframe": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
@@ -16600,6 +16729,15 @@
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/svgo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
@@ -16872,6 +17010,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/text-table": {
@@ -17346,6 +17493,15 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "class-variance-authority": "^0.7.0",
+    "jspdf": "^3.0.1",
+    "jspdf-autotable": "^5.0.2",
     "lucide-react": "^0.428.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/JsonTreeCompareViewer.jsx
+++ b/src/JsonTreeCompareViewer.jsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import { AlertCircle, ChevronDown, ChevronRight, Copy, RefreshCw, X, Save, FolderOpen, Trash2, HelpCircle } from 'lucide-react';
+import jsPDF from 'jspdf';
+import autoTable from 'jspdf-autotable';
+import { AlertCircle, ChevronDown, ChevronRight, Copy, RefreshCw, X, Save, FolderOpen, Trash2, HelpCircle, Download } from 'lucide-react';
 import { Alert, AlertDescription, AlertTitle } from './components/ui/alert';
 import { Button } from './components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from './components/ui/card';
@@ -326,6 +328,106 @@ const JsonTreeCompareViewer = () => {
     }
   };
 
+  const handleJsonDownload = () => {
+    if (!parsedLeft || !parsedRight || !comparisonStats) {
+      alert("Please perform a comparison first to generate a report.");
+      return;
+    }
+
+    const reportData = {
+      leftJson: parsedLeft,
+      rightJson: parsedRight,
+      statistics: comparisonStats,
+      timestamp: new Date().toISOString(),
+    };
+
+    const jsonString = JSON.stringify(reportData, null, 2);
+    const blob = new Blob([jsonString], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `json_comparison_report_${new Date().toISOString()}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  const handlePdfDownload = () => {
+    if (!parsedLeft || !parsedRight || !comparisonStats) {
+      alert("Please perform a comparison first to generate a report.");
+      return;
+    }
+
+    const doc = new jsPDF();
+    const timestamp = new Date().toISOString();
+
+    // Title
+    doc.setFontSize(18);
+    doc.text("JSON Comparison Report", 14, 22);
+
+    // Timestamp
+    doc.setFontSize(10);
+    doc.text(`Report generated on: ${timestamp}`, 14, 30);
+
+    // Statistics Table
+    const statMetrics = [
+      { key: 'totalLeftItems', label: 'Total Properties/Elements (Left)' },
+      { key: 'totalRightItems', label: 'Total Properties/Elements (Right)' },
+      { key: 'commonPaths', label: 'Common Paths (Keys/Indices)' },
+      { key: 'matchingValues', label: 'Matching Values (at Common Paths)' },
+      { key: 'differentValues', label: 'Different Values (at Common Paths)' },
+      { key: 'onlyInLeft', label: 'Exclusive to Left (Paths)' },
+      { key: 'onlyInRight', label: 'Exclusive to Right (Paths)' },
+    ];
+    
+    const tableBody = statMetrics.map(metric => [
+      metric.label,
+      comparisonStats[metric.key] !== undefined && comparisonStats[metric.key] !== null 
+        ? comparisonStats[metric.key].toLocaleString() 
+        : 'N/A'
+    ]);
+
+    autoTable(doc, {
+      startY: 40,
+      head: [['Metric', 'Value']],
+      body: tableBody,
+      theme: 'striped',
+      headStyles: { fillColor: [22, 160, 133] }, // Dark cyan
+      margin: { top: 10 }
+    });
+    
+    // Summary of Differences
+    let finalY = (doc).lastAutoTable.finalY || 50; // Get Y position after the table
+    doc.setFontSize(14);
+    doc.text("Summary of Differences", 14, finalY + 10);
+
+    doc.setFontSize(10);
+    let summaryTextY = finalY + 18;
+    doc.text(`- Items only in Left JSON: ${comparisonStats.onlyInLeft}`, 14, summaryTextY);
+    summaryTextY += 7;
+    doc.text(`- Items only in Right JSON: ${comparisonStats.onlyInRight}`, 14, summaryTextY);
+    summaryTextY += 7;
+    doc.text(`- Items with different values: ${comparisonStats.differentValues}`, 14, summaryTextY);
+
+    // Optionally, list a few differing paths (simplified)
+    if (comparisonStats.differences && comparisonStats.differences.length > 0) {
+      summaryTextY += 10;
+      doc.setFontSize(12);
+      doc.text("Examples of differing paths:", 14, summaryTextY);
+      doc.setFontSize(9);
+      summaryTextY += 6;
+      const maxExamples = 5;
+      comparisonStats.differences.slice(0, maxExamples).forEach((diff, index) => {
+        if (summaryTextY > 280) return; // Avoid going off page
+        doc.text(`  - Path: ${diff.path}`, 14, summaryTextY);
+        summaryTextY += 5;
+      });
+    }
+    
+    doc.save(`json_comparison_report_${timestamp}.pdf`);
+  };
+
   return (
     <div className={`p-4 max-w-7xl mx-auto ${darkMode ? 'dark' : ''}`}>
       <div className="dark:bg-gray-800 dark:text-white transition-colors duration-200">
@@ -376,6 +478,28 @@ const JsonTreeCompareViewer = () => {
                 aria-label="Open help section"
               >
                 <HelpCircle className="h-4 w-4" />
+              </Button>
+              <Button 
+                variant="outline" 
+                size="icon" 
+                onClick={handleJsonDownload} 
+                className="dark:text-white dark:border-white"
+                aria-label="Download JSON Report"
+                title="Download JSON Report"
+                disabled={!parsedLeft || !parsedRight || !comparisonStats}
+              >
+                <Download className="h-4 w-4" /> 
+              </Button>
+              <Button 
+                variant="outline" 
+                size="icon" 
+                onClick={handlePdfDownload} 
+                className="dark:text-white dark:border-white"
+                aria-label="Download PDF Report"
+                title="Download PDF Report"
+                disabled={!parsedLeft || !parsedRight || !comparisonStats}
+              >
+                <Download className="h-4 w-4" /> 
               </Button>
             </div>
           </CardHeader>

--- a/src/JsonTreeCompareViewer.jsx
+++ b/src/JsonTreeCompareViewer.jsx
@@ -145,6 +145,38 @@ const JsonTreeCompareViewer = () => {
     }
   }, [searchQuery, parsedLeft, parsedRight]);
 
+  // Keyboard shortcuts
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+      const modifierKey = isMac ? event.metaKey : event.ctrlKey;
+
+      if (modifierKey && event.shiftKey && event.key === 'C') {
+        event.preventDefault();
+        handleCopy('left'); // Or 'right', or implement a way to choose
+        console.log("Left JSON copied to clipboard via shortcut.");
+      } else if (modifierKey && event.shiftKey && event.key === 'L') {
+        event.preventDefault();
+        handleClear('left');
+        console.log("Left JSON cleared via shortcut.");
+      } else if (modifierKey && event.shiftKey && event.key === 'R') {
+        event.preventDefault();
+        handleClear('right');
+        console.log("Right JSON cleared via shortcut.");
+      } else if (modifierKey && event.key.toLowerCase() === 'd') { // Cmd+D or Ctrl+D, ensure lowercase 'd'
+        event.preventDefault();
+        toggleDarkMode();
+        console.log("Dark mode toggled via shortcut.");
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []); // Empty dependency array means this effect runs once on mount and cleans up on unmount
+
   const handleCompare = () => {
     try {
       const pLeft = JSON.parse(leftJson);

--- a/src/JsonTreeCompareViewer.test.js
+++ b/src/JsonTreeCompareViewer.test.js
@@ -562,3 +562,77 @@ describe('JsonTreeCompareViewer Integration Tests', () => {
       });
   });
 });
+
+// --- Keyboard Shortcut Tests ---
+describe('JsonTreeCompareViewer Keyboard Shortcuts', () => {
+  let consoleLogSpy;
+
+  beforeEach(() => {
+    // Spy on console.log before each test in this suite
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    // Ensure navigator.clipboard.writeText is fresh for each test
+    navigator.clipboard.writeText.mockClear(); 
+  });
+
+  afterEach(() => {
+    // Restore console.log
+    consoleLogSpy.mockRestore();
+    // Clear the class list for documentElement after dark mode tests
+    document.documentElement.classList.remove('dark');
+  });
+
+  const testCases = [
+    { description: 'Ctrl', keyProps: { ctrlKey: true, metaKey: false } },
+    { description: 'Meta (Cmd)', keyProps: { ctrlKey: false, metaKey: true } },
+  ];
+
+  testCases.forEach(({ description, keyProps }) => {
+    describe(`With ${description} Key`, () => {
+      test(`toggles dark mode with ${description}+D`, () => {
+        render(<JsonTreeCompareViewer />);
+        expect(document.documentElement.classList.contains('dark')).toBe(false);
+
+        fireEvent.keyDown(document, { key: 'd', ...keyProps });
+        expect(document.documentElement.classList.contains('dark')).toBe(true);
+        expect(consoleLogSpy).toHaveBeenCalledWith('Dark mode toggled via shortcut.');
+
+        fireEvent.keyDown(document, { key: 'D', ...keyProps }); // Test with uppercase D
+        expect(document.documentElement.classList.contains('dark')).toBe(false);
+        expect(consoleLogSpy).toHaveBeenCalledWith('Dark mode toggled via shortcut.');
+      });
+
+      test(`copies left JSON with ${description}+Shift+C`, () => {
+        const { getByPlaceholderText } = render(<JsonTreeCompareViewer />);
+        const leftInput = getByPlaceholderText('Enter left JSON here');
+        const testJson = '{"name":"test"}';
+        fireEvent.change(leftInput, { target: { value: testJson } });
+
+        fireEvent.keyDown(document, { key: 'C', shiftKey: true, ...keyProps });
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(testJson);
+        expect(consoleLogSpy).toHaveBeenCalledWith('Left JSON copied to clipboard via shortcut.');
+      });
+
+      test(`clears left JSON with ${description}+Shift+L`, () => {
+        const { getByPlaceholderText } = render(<JsonTreeCompareViewer />);
+        const leftInput = getByPlaceholderText('Enter left JSON here');
+        fireEvent.change(leftInput, { target: { value: '{"data":"left"}' } });
+        expect(leftInput.value).toBe('{"data":"left"}');
+
+        fireEvent.keyDown(document, { key: 'L', shiftKey: true, ...keyProps });
+        expect(leftInput.value).toBe('');
+        expect(consoleLogSpy).toHaveBeenCalledWith('Left JSON cleared via shortcut.');
+      });
+
+      test(`clears right JSON with ${description}+Shift+R`, () => {
+        const { getByPlaceholderText } = render(<JsonTreeCompareViewer />);
+        const rightInput = getByPlaceholderText('Enter right JSON here');
+        fireEvent.change(rightInput, { target: { value: '{"data":"right"}' } });
+        expect(rightInput.value).toBe('{"data":"right"}');
+
+        fireEvent.keyDown(document, { key: 'R', shiftKey: true, ...keyProps });
+        expect(rightInput.value).toBe('');
+        expect(consoleLogSpy).toHaveBeenCalledWith('Right JSON cleared via shortcut.');
+      });
+    });
+  });
+});

--- a/src/JsonTreeCompareViewer.test.js
+++ b/src/JsonTreeCompareViewer.test.js
@@ -563,6 +563,131 @@ describe('JsonTreeCompareViewer Integration Tests', () => {
   });
 });
 
+// --- Download Functionality Tests ---
+describe('Download Functionality', () => {
+  const leftJson = { name: 'Left', value: 1 };
+  const rightJson = { name: 'Right', value: 2 };
+  const leftJsonString = JSON.stringify(leftJson);
+  const rightJsonString = JSON.stringify(rightJson);
+
+  let createObjectURLMock;
+  let revokeObjectURLMock;
+  let anchorClickMock;
+
+  beforeEach(() => {
+    // Mock URL.createObjectURL and URL.revokeObjectURL
+    createObjectURLMock = jest.fn().mockReturnValue('mock-url');
+    revokeObjectURLMock = jest.fn();
+    global.URL.createObjectURL = createObjectURLMock;
+    global.URL.revokeObjectURL = revokeObjectURLMock;
+
+    // Mock anchor element click
+    anchorClickMock = jest.fn();
+    HTMLAnchorElement.prototype.click = anchorClickMock; // Mocking the click method
+    
+    // Mock jsPDF and autoTable
+    jest.mock('jspdf', () => {
+      const mockSave = jest.fn();
+      const mockText = jest.fn();
+      const mockSetFontSize = jest.fn();
+      // Mock the lastAutoTable property for jsPDF instance
+      const mockInstance = {
+        save: mockSave,
+        text: mockText,
+        setFontSize: mockSetFontSize,
+        lastAutoTable: { finalY: 50 }, 
+      };
+      return jest.fn(() => mockInstance);
+    });
+
+    jest.mock('jspdf-autotable', () => jest.fn());
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks(); // Restores original implementations
+    jest.unmock('jspdf'); // Unmock jspdf
+    jest.unmock('jspdf-autotable'); // Unmock jspdf-autotable
+    // Clean up specific mocks if necessary, though restoreAllMocks should handle most.
+    if (HTMLAnchorElement.prototype.click === anchorClickMock) {
+        delete HTMLAnchorElement.prototype.click; // Or restore original if saved
+    }
+  });
+
+  test('Download buttons are initially disabled and enabled after comparison', async () => {
+    render(<JsonTreeCompareViewer />);
+    const downloadJsonButton = screen.getByRole('button', { name: 'Download JSON Report' });
+    const downloadPdfButton = screen.getByRole('button', { name: 'Download PDF Report' });
+
+    expect(downloadJsonButton).toBeDisabled();
+    expect(downloadPdfButton).toBeDisabled();
+
+    fireEvent.change(screen.getByPlaceholderText('Enter left JSON here'), { target: { value: leftJsonString } });
+    fireEvent.change(screen.getByPlaceholderText('Enter right JSON here'), { target: { value: rightJsonString } });
+    fireEvent.click(screen.getByText('Compare'));
+
+    await waitFor(() => {
+      expect(downloadJsonButton).not.toBeDisabled();
+      expect(downloadPdfButton).not.toBeDisabled();
+    });
+  });
+  
+  test('Download JSON Report functionality', async () => {
+    render(<JsonTreeCompareViewer />);
+    fireEvent.change(screen.getByPlaceholderText('Enter left JSON here'), { target: { value: leftJsonString } });
+    fireEvent.change(screen.getByPlaceholderText('Enter right JSON here'), { target: { value: rightJsonString } });
+    fireEvent.click(screen.getByText('Compare'));
+    
+    const downloadJsonButton = await screen.findByRole('button', { name: 'Download JSON Report' });
+    expect(downloadJsonButton).not.toBeDisabled();
+    fireEvent.click(downloadJsonButton);
+
+    expect(createObjectURLMock).toHaveBeenCalledTimes(1);
+    const blob = createObjectURLMock.mock.calls[0][0];
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe('application/json');
+
+    const blobText = await blob.text(); // Read the Blob's content
+    const reportData = JSON.parse(blobText);
+    expect(reportData.leftJson).toEqual(leftJson);
+    expect(reportData.rightJson).toEqual(rightJson);
+    expect(reportData.statistics).toBeDefined();
+    expect(reportData.timestamp).toBeDefined();
+
+    const downloadAttribute = document.querySelector('a[download]');
+    expect(downloadAttribute.download).toMatch(/^json_comparison_report_.*\.json$/);
+    expect(anchorClickMock).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURLMock).toHaveBeenCalledWith('mock-url');
+  });
+
+  test('Download PDF Report functionality', async () => {
+    const { jsPDF } = require('jspdf'); // Retrieve the mocked constructor
+    const autoTable = require('jspdf-autotable'); // Retrieve the mocked function
+    
+    render(<JsonTreeCompareViewer />);
+    fireEvent.change(screen.getByPlaceholderText('Enter left JSON here'), { target: { value: leftJsonString } });
+    fireEvent.change(screen.getByPlaceholderText('Enter right JSON here'), { target: { value: rightJsonString } });
+    fireEvent.click(screen.getByText('Compare'));
+
+    const downloadPdfButton = await screen.findByRole('button', { name: 'Download PDF Report' });
+    expect(downloadPdfButton).not.toBeDisabled();
+    fireEvent.click(downloadPdfButton);
+    
+    expect(jsPDF).toHaveBeenCalledTimes(1);
+    const mockPdfInstance = jsPDF.mock.results[0].value;
+
+    expect(mockPdfInstance.text).toHaveBeenCalledWith("JSON Comparison Report", 14, 22);
+    expect(mockPdfInstance.text).toHaveBeenCalledWith(expect.stringContaining("Report generated on:"), 14, 30);
+    
+    expect(autoTable).toHaveBeenCalledTimes(1);
+    expect(autoTable.mock.calls[0][1].head).toEqual([['Metric', 'Value']]);
+    expect(autoTable.mock.calls[0][1].body.length).toBeGreaterThan(0); // Check that some stats rows were passed
+    
+    expect(mockPdfInstance.save).toHaveBeenCalledTimes(1);
+    expect(mockPdfInstance.save).toHaveBeenCalledWith(expect.stringMatching(/^json_comparison_report_.*\.pdf$/));
+  });
+});
+
+
 // --- Keyboard Shortcut Tests ---
 describe('JsonTreeCompareViewer Keyboard Shortcuts', () => {
   let consoleLogSpy;

--- a/src/components/HelpModal.jsx
+++ b/src/components/HelpModal.jsx
@@ -112,8 +112,27 @@ const HelpModal = ({ isOpen, onClose }) => {
             </ul>
           </section>
 
+          <section className="mb-4">
+            <h4 className="text-lg font-semibold mb-2 text-gray-800 dark:text-white">VIII. Keyboard Shortcuts</h4>
+            <p className="mb-1">Use these shortcuts for faster navigation and actions:</p>
+            <ul className="list-disc list-inside space-y-1 pl-4">
+              <li>
+                <strong>Toggle Dark Mode:</strong> <kbd>Ctrl</kbd> + <kbd>D</kbd> (or <kbd>Cmd</kbd> + <kbd>D</kbd> on Mac)
+              </li>
+              <li>
+                <strong>Copy Left JSON:</strong> <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd> (or <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd> on Mac)
+              </li>
+              <li>
+                <strong>Clear Left JSON:</strong> <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>L</kbd> (or <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>L</kbd> on Mac)
+              </li>
+              <li>
+                <strong>Clear Right JSON:</strong> <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>R</kbd> (or <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>R</kbd> on Mac)
+              </li>
+            </ul>
+          </section>
+
           <section>
-            <h4 className="text-lg font-semibold mb-2 text-gray-800 dark:text-white">VIII. Tips for Effective Use</h4>
+            <h4 className="text-lg font-semibold mb-2 text-gray-800 dark:text-white">IX. Tips for Effective Use</h4>
             <ul className="list-disc list-inside space-y-1">
               <li>For large JSON, use the search and expand/collapse features to navigate efficiently.</li>
               <li>Ensure your JSON is valid before pasting. Online JSON validators can help if you encounter issues.</li>


### PR DESCRIPTION

Adds the ability for you to download the JSON comparison results in two formats:
- JSON: A .json file containing the left JSON, right JSON, comparison statistics, and a timestamp.
- PDF: A .pdf file containing a formatted report with a title, timestamp, comparison statistics table, and a summary of differences.

Key changes:
- Installed `jspdf` and `jspdf-autotable` for PDF generation.
- Added "Download JSON Report" and "Download PDF Report" buttons to the `JsonTreeCompareViewer` component.
- Implemented the logic to generate and trigger downloads for both JSON and PDF formats.
- Buttons are disabled when no comparison data is available.
- Added comprehensive unit tests for the new download functionalities, including mocking necessary browser APIs and PDF generation libraries.

https://github.com/pavankalyan-nvs/json-tree-compare-viewer/issues/6